### PR TITLE
added functionality to pass 1 extra parameter to alert() function tha…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ The different 'levels' are:
 The different arguments:
 - `alert()->info('Title', 'Lorem Ipsum', false);` // without the icon
 - `alert()->info('Title', 'Lorem Ipsum', 'smile-o');` // specify the icon class
-- `alert()->message('Title', 'Lorem Ipsum', 'smile-o', 'info');` // specify the type of level
-- `alert()->message('Title', 'Lorem Ipsum', 'smile-o', 'info', false);` // do not show the 'close' button
+- `alert()->info('Title', 'Lorem Ipsum', 'smile-o', true);` // limit alert to the request lifecycle
+- `alert()->message('Title', 'Lorem Ipsum', 'smile-o', true, 'info');` // specify the type of level
+- `alert()->message('Title', 'Lorem Ipsum', 'smile-o', true, 'info', false);` // do not show the 'close'
 
 If you need to modify the view partial, you can run:
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -28,9 +28,9 @@ class Alert
      * @param             $content
      * @param bool|string $icon
      */
-    public function info($title, $content = '', $icon = true)
+    public function info($title, $content = '', $icon = true, $showOnce = false)
     {
-        $this->message($title, $content, $icon, 'info');
+        $this->message($title, $content, $icon, $showOnce, 'info');
     }
 
     /**
@@ -38,9 +38,9 @@ class Alert
      * @param             $content
      * @param bool|string $icon
      */
-    public function success($title, $content = '', $icon = true)
+    public function success($title, $content = '', $icon = true, $showOnce = false)
     {
-        $this->message($title, $content, $icon, 'success');
+        $this->message($title, $content, $icon, $showOnce, 'success');
     }
 
     /**
@@ -48,9 +48,9 @@ class Alert
      * @param             $content
      * @param bool|string $icon
      */
-    public function error($title, $content = '', $icon = true)
+    public function error($title, $content = '', $icon = true, $showOnce = false)
     {
-        $this->message($title, $content, $icon, 'danger');
+        $this->message($title, $content, $icon, $showOnce, 'danger');
     }
 
     /**
@@ -58,9 +58,9 @@ class Alert
      * @param             $content
      * @param bool|string $icon
      */
-    public function danger($title, $content = '', $icon = true)
+    public function danger($title, $content = '', $icon = true, $showOnce = false)
     {
-        $this->message($title, $content, $icon, 'danger');
+        $this->message($title, $content, $icon, $showOnce, 'danger');
     }
 
     /**
@@ -68,9 +68,9 @@ class Alert
      * @param             $content
      * @param bool|string $icon
      */
-    public function warning($title, $content = '', $icon = true)
+    public function warning($title, $content = '', $icon = true, $showOnce = false)
     {
-        $this->message($title, $content, $icon, 'warning');
+        $this->message($title, $content, $icon, $showOnce, 'warning');
     }
 
     /**
@@ -80,18 +80,27 @@ class Alert
      * @param string      $level
      * @param bool        $close
      */
-    public function message($title, $content, $icon, $level = 'info', $close = true)
+    public function message($title, $content, $icon, $showOnce, $level = 'info', $close = true)
     {
-        $this->session->flash('alert.title', $title);
-        $this->session->flash('alert.content', $content);
-        $this->session->flash('alert.level', $level);
-        $this->session->flash('alert.close', $close);
-
+        if($showOnce){
+            $this->session->now('alert.title', $title);
+            $this->session->now('alert.content', $content);
+            $this->session->now('alert.level', $level);
+            $this->session->now('alert.close', $close);
+        } else {
+            $this->session->flash('alert.title', $title);
+            $this->session->flash('alert.content', $content);
+            $this->session->flash('alert.level', $level);
+            $this->session->flash('alert.close', $close);
+        }
         // if icon == true, get icon from level, else if icon is string, set icon
         if ((is_bool($icon) && $icon == true) || strlen($icon) > 1) {
             $icon = is_string($icon) ? $icon : alert_icon($level);
-
-            $this->session->flash('alert.icon', $icon);
+            if($showOnce){
+                $this->session->now('alert.icon', $icon);
+            } else {
+                $this->session->flash('alert.icon', $icon);
+            }
         }
     }
 }


### PR DESCRIPTION
…t allows the user to limit the alert to the associated request. The reason for the suggested change is due to a problem I encountered where the session key alert.title etc persists over multiple request. I tried to pass the actual request instance but this seems to be inherent to the flash() function. The solution I found in this thread: https://stackoverflow.com/questions/24579580/laravel-session-flash-persists-for-2-requests